### PR TITLE
🐛 [BUG] Fix missing comma in train.py.

### DIFF
--- a/videollama2/train.py
+++ b/videollama2/train.py
@@ -783,7 +783,7 @@ def train(attn_implementation=None):
             config = transformers.AutoConfig.from_pretrained(model_args.model_name_or_path, trust_remote_code=True)
             config._attn_implementation = attn_implementation
             model = Videollama2MistralForCausalLM.from_pretrained(
-                pretrain_model_name_or_path
+                pretrain_model_name_or_path,
                 config=config,
                 cache_dir=training_args.cache_dir,
                 torch_dtype=(torch.bfloat16 if training_args.bf16 else None),
@@ -794,7 +794,7 @@ def train(attn_implementation=None):
             config = transformers.AutoConfig.from_pretrained(model_args.model_name_or_path, trust_remote_code=True)
             config._attn_implementation = attn_implementation
             model = Videollama2MixtralForCausalLM.from_pretrained(
-                pretrain_model_name_or_path
+                pretrain_model_name_or_path,
                 config=config,
                 cache_dir=training_args.cache_dir,
                 torch_dtype=(torch.bfloat16 if training_args.bf16 else None),
@@ -807,7 +807,7 @@ def train(attn_implementation=None):
             config = transformers.AutoConfig.from_pretrained(model_args.model_name_or_path, trust_remote_code=True)
             config._attn_implementation = attn_implementation
             model = Videollama2LlamaForCausalLM.from_pretrained(
-                pretrain_model_name_or_path
+                pretrain_model_name_or_path,
                 config=config,
                 cache_dir=training_args.cache_dir,
                 torch_dtype=(torch.bfloat16 if training_args.bf16 else None),
@@ -818,7 +818,7 @@ def train(attn_implementation=None):
         config = transformers.AutoConfig.from_pretrained(model_args.model_name_or_path, trust_remote_code=True)
         config._attn_implementation = attn_implementation
         model = transformers.LlamaForCausalLM.from_pretrained(
-            pretrain_model_name_or_path
+            pretrain_model_name_or_path,
             config=config,
             cache_dir=training_args.cache_dir,
             torch_dtype=(torch.bfloat16 if training_args.bf16 else None),


### PR DESCRIPTION
Fix the following error by adding the missing commas:

```
SyntaxError: invalid syntax. Perhaps you forgot a comma?
Traceback (most recent call last):
  File "/home/benoit/VideoLLaMA2/videollama2/train_flash_attn.py", line 9, in <module>
    from videollama2.train import train
  File "/home/benoit/VideoLLaMA2/./videollama2/train.py", line 786
    pretrain_model_name_or_path
    ^^^^^^^^^^^^^^^^^^^^^^^^^^^
```