### PR TITLE
🐛 [Bug] Fix mistral tokenizer bug and related issues.

### DIFF
--- a/README.md
+++ b/README.md
@@ -50,14 +50,15 @@ Basic Dependencies:
 * Python >= 3.8
 * Pytorch >= 2.0.1
 * CUDA Version >= 11.7
-* transformers >= 4.37.2
+* transformers >= 4.40.0 (for mistral tokenizer)
+* tokenizers >= 0.19.1 (for mistral tokenizer)
 
 **[Online Mode]** Install required packages (better for development):
 ```bash
 git clone https://github.com/DAMO-NLP-SG/VideoLLaMA2
 cd VideoLLaMA2
 pip install -r requirements.txt
-pip install flash-attn --no-build-isolation
+pip install flash-attn==2.5.8 --no-build-isolation
 ```
 
 **[Offline Mode]** Install VideoLLaMA2 as a Python package (better for direct use):
@@ -66,7 +67,7 @@ git clone https://github.com/DAMO-NLP-SG/VideoLLaMA2
 cd VideoLLaMA2
 pip install --upgrade pip  # enable PEP 660 support
 pip install -e .
-pip install flash-attn --no-build-isolation
+pip install flash-attn==2.5.8 --no-build-isolation
 ```
 
 ## 🚀 Main Results

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,10 +2,10 @@
 # basic dependencies
 torch==2.0.1
 torchvision==0.15.2
-transformers==4.37.2
-tokenizers==0.15.1
+transformers==4.40.0
+tokenizers==0.19.1
 deepspeed==0.13.1
-accelerate==0.21.0
+accelerate==0.26.1
 peft==0.4.0
 timm==1.0.3
 numpy==1.24.4


### PR DESCRIPTION
Because mistral update the tokenizer, some bugs occur when adopting previous `requirements.txt`.

## Items

* tokenizer bug: [Error when loading tokenizer from a file: data did not match any variant of untagged enum ModelWrapper](https://github.com/huggingface/tokenizers/issues/1297)
updating `transformers==4.40.0 tokenizers==0.19.1` can fix this bug.

* accelerate bug: [TypeError: Accelerator.__init__() got an unexpected keyword argument 'use_seedable_sampler'](https://github.com/huggingface/transformers/issues/29216#issuecomment-1960685746)
updating `accelerate==0.26.1` can fix this bug.
