### PR TITLE
Avoiding the frozen when save checkpoint using LoRA finetune.

### DIFF
--- a/videollama2/videollama2_trainer.py
+++ b/videollama2/videollama2_trainer.py
@@ -351,9 +351,10 @@ class VideoLLaMA2Trainer(Trainer):
 
                 run_dir = self._get_output_dir(trial=trial)
                 output_dir = os.path.join(run_dir, checkpoint_folder)
+
+                state_dict = get_peft_state_maybe_zero_3(self.model.named_parameters(), self.args.lora_bias)
+                non_lora_state_dict = get_peft_state_non_lora_maybe_zero_3(self.model.named_parameters())
                 if self.args.local_rank == 0 or self.args.local_rank == -1:
-                    state_dict = get_peft_state_maybe_zero_3(self.model.named_parameters(), self.args.lora_bias)
-                    non_lora_state_dict = get_peft_state_non_lora_maybe_zero_3(self.model.named_parameters())
                     # save for acquring `config.json`
                     self.model.config.save_pretrained(output_dir)
                     # save for acquring `adapter_config.json`, `adapter_model.bin`


### PR DESCRIPTION
When avoiding the use of LoRA for multi-GPU training to obtain the state_dict, if tensors are distributed across multiple GPUs, it can lead to a situation where they cannot be retrieved, causing the process to stall.

just follow the style in [train.py](https://github.com/DAMO-NLP-SG/VideoLLaMA2/blob/08d91fcf2a55d5f1dc71d9db2629512c660e4db6/videollama2/train.py#L875)