### PR TITLE
Change the __init__.py file to use the relevant pretrained function

### DIFF
--- a/videollama2/model/__init__.py
+++ b/videollama2/model/__init__.py
@@ -102,7 +102,9 @@ def load_pretrained_model(model_path, model_base, model_name, load_8bit=False, l
         elif 'mistral' in model_base.lower():
             model = Videollama2MistralForCausalLM.from_pretrained(model_base, low_cpu_mem_usage=True, config=config, **kwargs)
         else:
-            model = Videollama2MistralForCausalLM.from_pretrained(model_base, low_cpu_mem_usage=True, config=config, **kwargs)
+            #model = Videollama2MistralForCausalLM.from_pretrained(model_base, low_cpu_mem_usage=True, config=config, **kwargs)
+            # Using the visual@MistralForCasualLM will cause the model to give random output when using finetuned qwen2 based varient 
+            model = Videollama2Qwen2ForCausalLM.from_pretrained(model_base, low_cpu_mem_usage=True, config=config, **kwargs)
 
         token_num, tokem_dim = model.lm_head.out_features, model.lm_head.in_features
         if model.lm_head.weight.shape[0] != token_num:


### PR DESCRIPTION
Using the relevant pretrained function for loading the correct model when using a fine-tuned qlora version for qwen2 since in the original file we are using Videollama2MistralCausualLM for loading the pretrained model 
![image](https://github.com/user-attachments/assets/317728ee-1020-4ad1-aebd-433fb8a9a60e)
Which will give wrong result when loading a model that was fine-tuned using qlora. So added the model to load using  Videollama2Qwen2ForCausalLM as shown below  
![image](https://github.com/user-attachments/assets/87894816-52ba-4eec-9a50-3f41129ebd8d)
